### PR TITLE
fix(subdomains): regroup items when subdomains change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mark",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Automated tab management",
   "repository": "https://github.com/bradcush/mark.git",
   "author": "Bradley Cushing <bradleycushing@gmail.com>",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Mark tab manager",
     "description": "The missing tab manager for Chrome",
-    "version": "0.1.13",
+    "version": "0.1.14",
     "manifest_version": 3,
     "action": {
         "default_title": "Mark"


### PR DESCRIPTION
Cache tabs based on the granular group name when enabled so the cache is invalidated if a subdomain changes. Check against the subdomain cached to see if the subdomain has changed. (Closes #118)